### PR TITLE
feat: Mixerのgain/muteをスレッドセーフ化

### DIFF
--- a/crates/tone-core/src/mixer.rs
+++ b/crates/tone-core/src/mixer.rs
@@ -1,25 +1,51 @@
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
 use crate::graph::AudioNode;
 
-/// A track in the mixer.
+/// A track in the mixer with thread-safe parameter access.
 pub struct Track {
     /// The audio source for this track.
     pub node: Box<dyn AudioNode>,
-    /// Track gain (0.0-1.0).
-    pub gain: f32,
+    /// Track gain stored as f32 bits for atomic access.
+    gain_bits: AtomicU32,
     /// Mute this track.
-    pub mute: bool,
+    mute: AtomicBool,
     /// Solo this track (if any track is soloed, only soloed tracks play).
-    pub solo: bool,
+    solo: AtomicBool,
 }
 
 impl Track {
     pub fn new(node: Box<dyn AudioNode>) -> Self {
         Self {
             node,
-            gain: 1.0,
-            mute: false,
-            solo: false,
+            gain_bits: AtomicU32::new(1.0f32.to_bits()),
+            mute: AtomicBool::new(false),
+            solo: AtomicBool::new(false),
         }
+    }
+
+    pub fn gain(&self) -> f32 {
+        f32::from_bits(self.gain_bits.load(Ordering::Relaxed))
+    }
+
+    pub fn set_gain(&self, gain: f32) {
+        self.gain_bits.store(gain.to_bits(), Ordering::Relaxed);
+    }
+
+    pub fn is_muted(&self) -> bool {
+        self.mute.load(Ordering::Relaxed)
+    }
+
+    pub fn set_mute(&self, mute: bool) {
+        self.mute.store(mute, Ordering::Relaxed);
+    }
+
+    pub fn is_soloed(&self) -> bool {
+        self.solo.load(Ordering::Relaxed)
+    }
+
+    pub fn set_solo(&self, solo: bool) {
+        self.solo.store(solo, Ordering::Relaxed);
     }
 }
 
@@ -51,6 +77,11 @@ impl Mixer {
         idx
     }
 
+    /// Get a reference to a track by index.
+    pub fn track(&self, index: usize) -> Option<&Track> {
+        self.tracks.get(index)
+    }
+
     /// Get a mutable reference to a track by index.
     pub fn track_mut(&mut self, index: usize) -> Option<&mut Track> {
         self.tracks.get_mut(index)
@@ -63,7 +94,7 @@ impl Mixer {
 
     /// Check if any track is soloed.
     fn has_solo(&self) -> bool {
-        self.tracks.iter().any(|t| t.solo)
+        self.tracks.iter().any(|t| t.is_soloed())
     }
 }
 
@@ -85,12 +116,10 @@ impl AudioNode for Mixer {
         let has_solo = self.has_solo();
 
         for track in &mut self.tracks {
-            // Skip muted tracks
-            if track.mute {
+            if track.is_muted() {
                 continue;
             }
-            // If any track is soloed, only play soloed tracks
-            if has_solo && !track.solo {
+            if has_solo && !track.is_soloed() {
                 continue;
             }
 
@@ -98,13 +127,12 @@ impl AudioNode for Mixer {
             buf.fill(0.0);
             track.node.process(&[], buf, sample_rate);
 
-            let gain = track.gain;
+            let gain = track.gain();
             for (out, &t) in output.iter_mut().zip(buf.iter()) {
                 *out += t * gain;
             }
         }
 
-        // Apply master gain
         let mg = self.master_gain;
         for sample in output.iter_mut() {
             *sample *= mg;
@@ -143,7 +171,7 @@ mod tests {
             OscillatorType::Sine,
             440.0,
         ))));
-        mixer.track_mut(idx).unwrap().mute = true;
+        mixer.track(idx).unwrap().set_mute(true);
 
         let mut output = [0.0f32; 256];
         mixer.process(&[], &mut output, 44100);
@@ -156,25 +184,21 @@ mod tests {
     fn test_mixer_solo() {
         let mut mixer = Mixer::new();
 
-        // Track 0: 440Hz (not soloed)
         mixer.add_track(Track::new(Box::new(Oscillator::new(
             OscillatorType::Sine,
             440.0,
         ))));
-        // Track 1: 880Hz (soloed)
         let idx = mixer.add_track(Track::new(Box::new(Oscillator::new(
             OscillatorType::Sine,
             880.0,
         ))));
-        mixer.track_mut(idx).unwrap().solo = true;
+        mixer.track(idx).unwrap().set_solo(true);
 
         let mut output = [0.0f32; 256];
         mixer.process(&[], &mut output, 44100);
 
-        // Only the 880Hz track should play
         let max = output.iter().fold(0.0f32, |a, &b| a.max(b.abs()));
         assert!(max > 0.5, "solo track should produce audio");
-        // Max should be <= 1.0 (single oscillator, not summed)
         assert!(max <= 1.01, "only one track should be playing: max={max}");
     }
 
@@ -185,12 +209,31 @@ mod tests {
             OscillatorType::Sine,
             440.0,
         ))));
-        mixer.track_mut(idx).unwrap().gain = 0.5;
+        mixer.track(idx).unwrap().set_gain(0.5);
 
         let mut output = [0.0f32; 256];
         mixer.process(&[], &mut output, 44100);
 
         let max = output.iter().fold(0.0f32, |a, &b| a.max(b.abs()));
         assert!(max > 0.3 && max < 0.6, "half-gain track: max={max}");
+    }
+
+    #[test]
+    fn test_mixer_thread_safe_setters() {
+        let mut mixer = Mixer::new();
+        let idx = mixer.add_track(Track::new(Box::new(Oscillator::new(
+            OscillatorType::Sine,
+            440.0,
+        ))));
+
+        // These should work through immutable reference (atomic)
+        let track = mixer.track(idx).unwrap();
+        track.set_gain(0.7);
+        track.set_mute(true);
+        track.set_solo(true);
+
+        assert!((track.gain() - 0.7).abs() < 0.01);
+        assert!(track.is_muted());
+        assert!(track.is_soloed());
     }
 }


### PR DESCRIPTION
## Summary
- Track の gain/mute/solo を Atomic 型に変更してスレッドセーフに
- `set_gain()`, `set_mute()`, `set_solo()` を `&self` (immutable ref) で呼べるように

## Changes
- `gain: f32` → `gain_bits: AtomicU32`
- `mute: bool` → `mute: AtomicBool`
- `solo: bool` → `solo: AtomicBool`
- getter/setter メソッド追加
- `track()` (immutable ref) メソッド追加
- スレッドセーフテスト追加

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)