### PR TITLE
fix: Player/GrainPlayerのサンプルレート不一致による音程ズレ

### DIFF
--- a/crates/tone-core/src/source/grain_player.rs
+++ b/crates/tone-core/src/source/grain_player.rs
@@ -161,13 +161,14 @@ impl GrainPlayer {
 }
 
 impl AudioNode for GrainPlayer {
-    fn process(&mut self, _input: &[f32], output: &mut [f32], _sample_rate: u32) {
+    fn process(&mut self, _input: &[f32], output: &mut [f32], sample_rate: u32) {
         if !self.playing || self.buffer.is_empty() {
             output.fill(0.0);
             return;
         }
 
-        let rate = self.playback_rate() as f64;
+        let rate_ratio = self.buffer.sample_rate as f64 / sample_rate as f64;
+        let rate = self.playback_rate() as f64 * rate_ratio;
         let grain_samples = (self.grain_size() * self.sample_rate as f32) as usize;
         let hop = ((1.0 - self.overlap()) * grain_samples as f32) as usize;
         let hop = hop.max(1);
@@ -199,7 +200,7 @@ impl AudioNode for GrainPlayer {
                 let window = grain.window(pos);
                 sum += self.buffer.data[buf_idx] * window;
 
-                grain.position += 1.0; // grains always read at original pitch
+                grain.position += rate_ratio; // compensate for sample rate difference
             }
 
             *sample = sum;

--- a/crates/tone-core/src/source/player.rs
+++ b/crates/tone-core/src/source/player.rs
@@ -130,13 +130,14 @@ impl Player {
 }
 
 impl AudioNode for Player {
-    fn process(&mut self, _input: &[f32], output: &mut [f32], _sample_rate: u32) {
+    fn process(&mut self, _input: &[f32], output: &mut [f32], sample_rate: u32) {
         if !self.playing.load(Ordering::Relaxed) || self.buffer.is_empty() {
             output.fill(0.0);
             return;
         }
 
-        let rate = self.playback_rate() as f64;
+        let rate_ratio = self.buffer.sample_rate as f64 / sample_rate as f64;
+        let rate = self.playback_rate() as f64 * rate_ratio;
         let buf_len = self.buffer.data.len() as f64;
         let loop_enabled = self.loop_enabled.load(Ordering::Relaxed);
 
@@ -240,5 +241,31 @@ mod tests {
         assert!(output[1] > output[0]); // increasing
         // Second output sample should be roughly data[2] = 0.02
         assert!((output[1] - 0.02).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_player_sample_rate_compensation() {
+        // Buffer at 44100Hz, output at 48000Hz
+        // Without compensation, playback would be 48000/44100 ≈ 1.088x faster
+        let sr_buf = 44100u32;
+        let sr_out = 48000u32;
+        let data: Vec<f32> = (0..sr_buf)
+            .map(|i| (2.0 * std::f32::consts::PI * 440.0 * i as f32 / sr_buf as f32).sin())
+            .collect();
+        let buf = AudioBuffer::from_samples(data, sr_buf);
+        let mut player = Player::new(buf);
+        player.start();
+
+        // Process 48000 samples (1 second at output rate)
+        let mut output = vec![0.0f32; sr_out as usize];
+        player.process(&[], &mut output, sr_out);
+
+        // With rate compensation, position should advance by ~44100 samples
+        // (covering the full 1-second buffer), not 48000
+        // The player should still be playing (not past end of 44100-sample buffer)
+        assert!(
+            player.playing.load(Ordering::Relaxed),
+            "player should still be playing after 1s of output"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Player/GrainPlayer でバッファと出力のサンプルレート比率を補正
- 44100Hz WAV を 48000Hz AudioContext で再生しても正しい音程で再生される

## Changes
- **Player**: `position += playback_rate * (buffer_sr / output_sr)` に変更
- **GrainPlayer**: position 進行とグレイン内読み取り速度の両方を `rate_ratio` で補正
- テスト追加: 44100Hz バッファを 48000Hz で再生した場合の position 進行検証

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)