### PR TITLE
fix: GrainPlayerのget_position_secondsがバッファSRで割るように修正

### DIFF
--- a/crates/tone-core/src/source/grain_player.rs
+++ b/crates/tone-core/src/source/grain_player.rs
@@ -117,7 +117,7 @@ impl GrainPlayer {
     /// Get the current playback position in seconds (thread-safe).
     pub fn get_position_seconds(&self) -> f64 {
         let pos = f64::from_bits(self.position_bits.load(Ordering::Relaxed));
-        pos / self.sample_rate as f64
+        pos / self.buffer.sample_rate as f64
     }
 
     /// Get the total duration of the buffer in seconds.


### PR DESCRIPTION
## Summary
`get_position_seconds()` で `self.sample_rate` (出力SR) ではなく `self.buffer.sample_rate` (バッファSR) で割るように修正。

position はバッファ座標系で進むため、出力SR で割ると SR 不一致時に秒数がズレる。

## Test plan
- [x] `cargo test -p tone-core test_grain_player` 全パス
- [x] `cargo clippy -p tone-core -- -D warnings` パス

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)